### PR TITLE
In (a somewhat unconfigured) bash the $0 returned '-bash'. This

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,4 +1,8 @@
-THIS_FOLDER=`dirname $0`
+if [[ -v BASH_SOURCE ]]; then
+	THIS_FOLDER=`dirname $BASH_SOURCE[0]`
+else
+	THIS_FOLDER=`dirname $0`
+fi
 THIS_FOLDER=`readlink -f ${THIS_FOLDER}`
 
 export LD_LIBRARY_PATH=${THIS_FOLDER}/lib:${LD_LIBRARY_PATH}


### PR DESCRIPTION
obviously is not what was intended. In any case the correct output is
available in the variable BASH_SOURCE.

As BASH_SOURCE is not defined on zsh, I do a if-else checking if the
variable exists before using $0